### PR TITLE
Fixing gradle not exiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Fixed:
  -Application halt when warming up if logs directory wasn't present.
 
+### Added:
+ -Command: "-stopgd" which stops all Gradle Daemon background processes. Check the commands list for more details.
+
 # Version v0.0.2:
 
 ### Fixed:

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -12,10 +12,12 @@ You can execute with no command.
 
 ### Command Syntax
 
-Since version v0.0.2 all commands are preceded with a minus. There are no double-minus or slash comands. Some commands have an argument which has to be separated by a space. "command1" syntax is "-command1 argument".
+All commands are preceded with a minus. There are no double-minus or slash comands. Some commands have an argument which has to be separated by a space. "command1" syntax is "-command1 argument".
 
 ### Commands List
 
-- **warmup**: Only starts a gradle build. After execution is finished subsequent builds will be much faster. Only useful for automated execution or to save time if you have to wait for a build. No arguments needed.
+- **warmup**: Does not create a sticker pack. Only starts a gradle build. After execution is finished subsequent builds will be much faster. Only useful for automated execution or to save time if you have to wait for a build. No arguments needed.
 
 - **packname NAME**: Skips the "input packname" prompt and in it's place sets "NAME" to it. Replace NAME with any name. The name can't have any spaces and has to be between 3 and 32 characters. If these conditions aren't met build will stop.
+
+- **stopgd**: Does not create a sticker pack. Only stops [Gradle Daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html), a background application that keeps running after you execute WASPC. Recommended to use this command every time you stop using WASPC.

--- a/src/main/java/milanesa/stickerpackcreator/main/FileModifiers.java
+++ b/src/main/java/milanesa/stickerpackcreator/main/FileModifiers.java
@@ -124,6 +124,32 @@ public class FileModifiers {
         }
     }
 
+    /**
+     * Gradle keeps a background application to make subsequent builds faster. This application is called
+     * 'Gradle Daemon'. This method stops that process by calling 'gradlew.bat --stop'.
+     * @param mainDirPath path to where the .jar of this application is stored.
+     * @return exit code of the gradlew.bat process (-1 if an exception occurs).
+     */
+    static int stopGradleDaemons(String mainDirPath){
+        try {
+            System.out.println("[stopGradleDaemons] Stopping Gradle Daemons. This could take some time...");
+            ProcessBuilder gradlewProcessBuilder = new ProcessBuilder(mainDirPath.concat("\\android\\gradlew.bat"), "--stop");
+            gradlewProcessBuilder.directory(new File(mainDirPath.concat("/android")));
+
+            Process gradlewProcess = gradlewProcessBuilder.start();
+
+            createLoggingThread(mainDirPath, "Gradle (stopping daemon)", false, gradlewProcess.getInputStream());
+            createLoggingThread(mainDirPath, "Gradle (stopping daemon)", true, gradlewProcess.getErrorStream());
+
+            gradlewProcess.waitFor();
+            System.out.println("[stopGradleDaemons] Gradle Daemon process finished with code: "+gradlewProcess.exitValue()+".");
+            return gradlewProcess.exitValue();
+        }catch (Exception ex){
+            ex.printStackTrace();
+            return -1;
+        }
+    }
+
     static void createLoggingThread(String mainDirPath, String appToLog, boolean isError, InputStream streamToLog){
         DateFormat simpleDateFormat = new SimpleDateFormat("yyyyMMdd");
         Date currentDate = Date.from(Instant.now());

--- a/src/main/java/milanesa/stickerpackcreator/main/Main.java
+++ b/src/main/java/milanesa/stickerpackcreator/main/Main.java
@@ -210,6 +210,14 @@ public class Main {
             FileModifiers.startGradleBuild(jarPath);
             System.out.println("[CheckArguments] Gradle warmup finished. Next builds will be faster.");
             Runtime.getRuntime().exit(0);
+        }else if(argsList.contains("-stopgd")){
+            System.out.println("[CheckArguments] Stopping Gradle Daemon. This execution will not create a sticker pack.");
+            jarPath = FileGetters.getJarPath();
+            checkFolderConditions(jarPath, true);
+            int gdExitCode = FileModifiers.stopGradleDaemons(jarPath);
+            if(gdExitCode != 0) System.out.println("[CheckArguments] Gradle Daemon stopping process finished with error code: "+gdExitCode);
+            else System.out.println("[CheckArguments] Gradle Daemon stopped successfully.");
+            Runtime.getRuntime().exit(gdExitCode);
         }
     }
 }


### PR DESCRIPTION
This fixes #28 by adding a command to manually stop the Gradle Daemon.